### PR TITLE
THIn-217 Use old-releases for lucid

### DIFF
--- a/roles/basebox/defaults/main.yml
+++ b/roles/basebox/defaults/main.yml
@@ -10,7 +10,7 @@ boxes:
       "15": ubuntuutopic
       "16": ubuntu14.04
   basebox-lucid:
-    location: http://gb.archive.ubuntu.com/ubuntu/dists/lucid/main/installer-amd64/
+    location: http://old-releases.ubuntu.com/ubuntu/dists/lucid/main/installer-amd64/
     preseed: preseed-lucid.cfg.j2
     extra_args: "auto=true priority=critical preseed/locale=en_GB.UTF-8 console-setup/ask_detect=false kbd-chooser/method=en console-keymaps-at/keymap=gb url=file:///preseed.cfg quiet"
     variant: 

--- a/roles/basebox/templates/preseed-lucid.cfg.j2
+++ b/roles/basebox/templates/preseed-lucid.cfg.j2
@@ -7,7 +7,7 @@ d-i netcfg/get_hostname string {{username}}
 d-i netcfg/choose_interface select eth0
 # Mirror
 d-i mirror/country string manual
-d-i mirror/http/hostname string gb.archive.ubuntu.com
+d-i mirror/http/hostname string old-releases.ubuntu.com
 d-i mirror/http/directory string /ubuntu
 d-i mirror/http/proxy string
 

--- a/roles/basebox/templates/preseed-lucid.cfg.j2
+++ b/roles/basebox/templates/preseed-lucid.cfg.j2
@@ -11,6 +11,10 @@ d-i mirror/http/hostname string old-releases.ubuntu.com
 d-i mirror/http/directory string /ubuntu
 d-i mirror/http/proxy string
 
+d-i apt-setup/services-select multiselect security
+d-i apt-setup/security_host string old-releases.ubuntu.com
+d-i apt-setup/security_path string /ubuntu
+
 # Partitioning
 d-i partman-auto/disk string /dev/vda
 d-i partman-auto/method string lvm


### PR DESCRIPTION
To test, recreate basebox-lucid. Will work, without this patch, will no longer work 

Destroy platform cdh box. make

Should cleanly rebuild cdh VM.