### PR TITLE
Use SandyBridge cpu type for base boxes

### DIFF
--- a/roles/basebox/tasks/create.yml
+++ b/roles/basebox/tasks/create.yml
@@ -25,6 +25,7 @@
              --os-type linux 
              --os-variant {{boxes[box].variant[ansible_lsb.major_release]}}
              --vcpus {{ cpu }}
+             --cpu SandyBridge
              --location {{boxes[box].location}}
              --initrd-inject /tmp/preseed.cfg
              --extra-args "{{boxes[box].extra_args}}"


### PR DESCRIPTION
The spectre/ meltdown microcode fixes have disable some cpu flags. This causes libvirt to pick/ generate a processor type that then is incompatible with ubuntu 16.

This forces choosing of sandybridge, which I believe is a good baseline for the hardware in use by the dev team and gives compatible hardware for more historical ubuntu versions.